### PR TITLE
Fix sample code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ use rlogger::rlogger::RLogger;
 
 fn main() {
     let socket_path = "/path/to/rloggerd.sock";
-    let logger = RLogger::new(socket_path);
+    let mut logger = RLogger::new(socket_path);
     let tag = "this.is.tag";
     let msg = "this is application log";
     logger.write(tag, msg);


### PR DESCRIPTION
I got the following compile error message, when I try to compile sample code in `README.md`.

``` sh
src/main.rs:9:5: 9:11 error: cannot borrow immutable local variable `logger` as mutable
src/main.rs:9     logger.write(tag, msg);
                  ^~~~~~
src/main.rs:6:9: 6:15 note: use `mut logger` here to make mutable
src/main.rs:6     let logger = RLogger::new(socket_path);
```

Its error describe that `logger` variable must be mutable.
